### PR TITLE
Add fire charge as an item that can light a lantern

### DIFF
--- a/src/main/resources/data/hardcore_torches/tags/items/consume_lantern_light_items.json
+++ b/src/main/resources/data/hardcore_torches/tags/items/consume_lantern_light_items.json
@@ -1,5 +1,6 @@
 {
     "replace": false,
     "values": [
+        "minecraft:fire_charge"
     ]
 }


### PR DESCRIPTION
I added it to `consume_lantern_light_items.json` because it gets consumed when lighting a campfire as well.