### PR TITLE
Add shovels as items that can extinguish torches

### DIFF
--- a/src/main/resources/data/hardcore_torches/tags/items/damage_torch_extinguish_items.json
+++ b/src/main/resources/data/hardcore_torches/tags/items/damage_torch_extinguish_items.json
@@ -1,5 +1,11 @@
 {
     "replace": false,
     "values": [
+        "minecraft:wooden_shovel",
+        "minecraft:stone_shovel",
+        "minecraft:iron_shovel",
+        "minecraft:golden_shovel",
+        "minecraft:diamond_shovel",
+        "minecraft:netherite_shovel"
     ]
 }


### PR DESCRIPTION
I added it to `damage_torch_extinguish_items.json` because they get damaged when extinguishing a campfire as well.