### PR TITLE
Fix durability bug and add Tinkers Construct and Create compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,7 @@ dependencies {
     implementation(fg.deobf("curse.maven:lights-551736:6044481"));
     //implementation(fg.deobf("curse.maven:coroutil-237749:5096038"));
     //implementation(fg.deobf("curse.maven:weather2-237746:5244118"));
+    compileOnly(fg.deobf("curse.maven:tinkers-construct-74072:7449219"))
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/src/main/java/com/github/wolfiewaffle/hardcore_torches/blockentity/IFuelBlock.java
+++ b/src/main/java/com/github/wolfiewaffle/hardcore_torches/blockentity/IFuelBlock.java
@@ -1,18 +1,20 @@
 package com.github.wolfiewaffle.hardcore_torches.blockentity;
 
 import com.github.wolfiewaffle.hardcore_torches.MainMod;
+import com.github.wolfiewaffle.hardcore_torches.compat.tconstruct.TinkersConstructCompat;
 import com.github.wolfiewaffle.hardcore_torches.util.ETorchState;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TieredItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.fml.ModList;
 
 public interface IFuelBlock {
 
@@ -80,8 +82,11 @@ public interface IFuelBlock {
 
         // Durability items
         if (damage != null && stack.is(damage)) {
-            if (stack.isDamageableItem() && player instanceof ServerPlayer) {
-                stack.hurt(1, RandomSource.create(), (ServerPlayer) player);
+            if (ModList.get().isLoaded("tconstruct")) {
+                if (TinkersConstructCompat.isBroken(stack)) {
+                    return false;
+                }
+            }
             if (stack.isDamageableItem() && player instanceof ServerPlayer serverPlayer) {
                 stack.hurtAndBreak(1, serverPlayer, (p) -> {});
             }

--- a/src/main/java/com/github/wolfiewaffle/hardcore_torches/blockentity/IFuelBlock.java
+++ b/src/main/java/com/github/wolfiewaffle/hardcore_torches/blockentity/IFuelBlock.java
@@ -82,6 +82,8 @@ public interface IFuelBlock {
         if (damage != null && stack.is(damage)) {
             if (stack.isDamageableItem() && player instanceof ServerPlayer) {
                 stack.hurt(1, RandomSource.create(), (ServerPlayer) player);
+            if (stack.isDamageableItem() && player instanceof ServerPlayer serverPlayer) {
+                stack.hurtAndBreak(1, serverPlayer, (p) -> {});
             }
             return true;
         }

--- a/src/main/java/com/github/wolfiewaffle/hardcore_torches/compat/tconstruct/TinkersConstructCompat.java
+++ b/src/main/java/com/github/wolfiewaffle/hardcore_torches/compat/tconstruct/TinkersConstructCompat.java
@@ -1,0 +1,13 @@
+package com.github.wolfiewaffle.hardcore_torches.compat.tconstruct;
+
+import net.minecraft.world.item.ItemStack;
+import slimeknights.tconstruct.library.tools.nbt.ToolStack;
+
+public class TinkersConstructCompat {
+
+    public static boolean isBroken(ItemStack stack) {
+        ToolStack tool = ToolStack.from(stack);
+        return tool.isBroken();
+    }
+
+}

--- a/src/main/resources/data/create/tags/blocks/fan_processing_catalysts/smoking.json
+++ b/src/main/resources/data/create/tags/blocks/fan_processing_catalysts/smoking.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "hardcore_torches:hardcore_campfire",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
1. Fixes item durability going into the negatives and never breaking when lighting torches, lanterns, campfires (closes #46)

2. Adds Tinkers Construct compatibility so if users configure flint and brick (or any other Tinkers tool) to be able to light fires, it won't work when the tool is broken

3. Adds Create tag allowing lit hardcore campfires to smoke things with the encased fan, like regular campfires do

If you want to formalize the Tinkers Construct compatibility, you could find a way to add `tconstruct:flint_and_brick` to `damage_torch_light_items.json` and/or `damage_lantern_light_items.json` by default if Tinkers is loaded.

Developed on 1.20.1. All these methods exist 1.16+, but I only tested for 1.20.1 and wouldn't even know how to easily backport or forwardport on your Git branch system.